### PR TITLE
Allow additional AWS credential methods

### DIFF
--- a/mediathread/assetmgr/models.py
+++ b/mediathread/assetmgr/models.py
@@ -403,8 +403,8 @@ class Source(models.Model):
         if s3_private_bucket in self.url:
             return get_signed_s3_url(
                 self.url, s3_private_bucket,
-                settings.AWS_ACCESS_KEY,
-                settings.AWS_SECRET_KEY)
+                settings.AWS_ACCESS_KEY_ID,
+                settings.AWS_SECRET_ACCESS_KEY)
 
         if self.upload:
             return self.upload.url
@@ -419,8 +419,8 @@ class Source(models.Model):
         if s3_private_bucket in self.url:
             return get_signed_s3_url(
                 self.url, s3_private_bucket,
-                settings.AWS_ACCESS_KEY,
-                settings.AWS_SECRET_KEY)
+                settings.AWS_ACCESS_KEY_ID,
+                settings.AWS_SECRET_ACCESS_KEY)
 
         url_processor = getattr(settings, 'ASSET_URL_PROCESSOR')
         return url_processor(self.url, self.label, request)

--- a/mediathread/settings_docker.py
+++ b/mediathread/settings_docker.py
@@ -20,8 +20,8 @@ DB_PASSWORD = os.environ.get('DB_PASSWORD', '')
 
 AWS_S3_CUSTOM_DOMAIN = os.environ.get('AWS_S3_CUSTOM_DOMAIN', '')
 AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', '')
-AWS_ACCESS_KEY = os.environ.get('AWS_ACCESS_KEY', '')
-AWS_SECRET_KEY = os.environ.get('AWS_SECRET_KEY', '')
+AWS_ACCESS_KEY = os.environ.get('AWS_ACCESS_KEY', None)
+AWS_SECRET_KEY = os.environ.get('AWS_SECRET_KEY', None)
 AWS_ACCESS_KEY_ID = AWS_ACCESS_KEY
 AWS_SECRET_ACCESS_KEY = AWS_SECRET_KEY
 

--- a/mediathread/settings_docker.py
+++ b/mediathread/settings_docker.py
@@ -19,11 +19,9 @@ DB_USER = os.environ.get('DB_USER', '')
 DB_PASSWORD = os.environ.get('DB_PASSWORD', '')
 
 AWS_S3_CUSTOM_DOMAIN = os.environ.get('AWS_S3_CUSTOM_DOMAIN', '')
-AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', '')
-AWS_ACCESS_KEY = os.environ.get('AWS_ACCESS_KEY', None)
-AWS_SECRET_KEY = os.environ.get('AWS_SECRET_KEY', None)
-AWS_ACCESS_KEY_ID = AWS_ACCESS_KEY
-AWS_SECRET_ACCESS_KEY = AWS_SECRET_KEY
+S3_PRIVATE_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', '')
+AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY', None)
+AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_KEY', None)
 
 RAVEN_DSN = os.environ.get('RAVEN_DSN', '')
 
@@ -87,3 +85,16 @@ LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
 }
+
+PYLTI_CONFIG = {
+    'consumers': {
+        'key': {
+            'secret': os.environ.get('PYLTI_SECRET', '')
+        }
+    }
+}
+PANOPTO_SERVER=os.environ.get('PANOPTO_SERVER','')
+PANOPTO_API_USER=os.environ.get('PANOPTO_USER','')
+PANOPTO_INSTANCE_NAME=os.environ.get('PANOPTO_INSTANCE','')
+PANOPTO_API_PASSWORD=os.environ.get('PANOPTO_PASSWORD','')
+EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'


### PR DESCRIPTION
Setting keys to `None` value defaults the boto3 library to search for environment based credentials (.aws/credentials file, IAM roles, etc...). An empty string is treated as an actual value, and therefore always invalid when used.